### PR TITLE
fix(build): support Node v4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,22 @@
 language: node_js
 node_js:
-- "0.10"
+  - "0.10"
+  - "0.12"
+  - "4.2"
+  - "5.3"
 notifications:
   email:
     on_success: never
 env:
-- secure: HhvWoR88+eCkm+YXaIfGuBFMoBKxbnXFN618XqXlBwbpz+1se3YOxv0kX7265dDf7z3xPggkCrmQ+B+AinczUQ3n6rN9Q9utDD6HM5BBdcIeQ/zLQ8n9aQyCaQloThu+eE/ni2GpJ8oO+JlK2ox5Xoen1s4uTD6SxrCPPHAwgec=
+  global:
+    - CXX=g++-4.8
+    - secure: HhvWoR88+eCkm+YXaIfGuBFMoBKxbnXFN618XqXlBwbpz+1se3YOxv0kX7265dDf7z3xPggkCrmQ+B+AinczUQ3n6rN9Q9utDD6HM5BBdcIeQ/zLQ8n9aQyCaQloThu+eE/ni2GpJ8oO+JlK2ox5Xoen1s4uTD6SxrCPPHAwgec=
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 deploy:
   provider: npm
   email: carlos.manzanares+npm@gmail.com

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "npmlog": "0.0.6",
     "request": "2.x.x",
-    "ursa" : "~0.8.x",
+    "ursa" : "^0.9.x",
     "nopt": "2.2.x"
   },
   "engines": {

--- a/test/integration/travis-integration-test.js
+++ b/test/integration/travis-integration-test.js
@@ -3,8 +3,6 @@ var assert = require('../lib/extended-assert'),
 
 log.level = 'silent';
 
-var figaroJSONPath = './test/new_file.json';
-
 describe('figaro.travis', function () {
     describe('#getPublicKey', function () {
         it('should find public key', function (done) {
@@ -22,20 +20,6 @@ describe('figaro.travis', function () {
                 assert.ok(err);
                 assert.ok(!publicKey);
                 done();
-            });
-        });
-
-        describe('#decrypt', function () {
-            this.timeout(figaro.travis.networkTimeout);
-            it('should find PASSWORD environment variable', function (done) {
-                if (process.env.TRAVIS === 'true') {
-                    assert.equal(process.env.TRAVIS_SECURE_ENV_VARS, 'true');
-                    assert.equal(process.env.PASSWORD1, 'SuperSecretPassword');
-                    assert.equal(process.env.PASSWORD2, 'AnotherSuperSecretPassword');
-                    done();
-                } else {
-                    done();
-                }
             });
         });
     });


### PR DESCRIPTION
ursa v0.8.5 does not build on Node 4.x.
This is fixed in ursa v0.9.1.
Tell Travis to test on recent Node versions.
Tell Travis use a recent GCC version for Node 4.x+ support.
Remove useless `#decrypt` test as it does not test any figaro functions.
Remove unused var in integration tests.

Fixes #7.
